### PR TITLE
fix: ensure reconnection on all connection errors (socket + TLS + initial)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -254,6 +254,10 @@ export class DWClient extends EventEmitter {
       this.socket.on('error', (err) => {
         this.printDebug('SOCKET ERROR');
         console.warn('ERROR', err);
+        // Fix: Terminate socket on error to trigger 'close' event and ensure reconnection
+        // Without this, TLS handshake failures or other errors may not trigger 'close',
+        // causing the client to stay disconnected forever when autoReconnect is enabled
+        this.socket?.terminate();
       });
 
       resolve();

--- a/src/client.ts
+++ b/src/client.ts
@@ -200,7 +200,14 @@ export class DWClient extends EventEmitter {
       this.userDisconnect = false;
 
       this.printDebug('Connecting to dingtalk websocket @ ' + this.dw_url);
-      this.socket = new WebSocket(this.dw_url!, this.sslopts);
+      try {
+        this.socket = new WebSocket(this.dw_url!, this.sslopts);
+      } catch (err) {
+        this.printDebug('WebSocket constructor error');
+        console.warn('ERROR', err);
+        reject(err);
+        return;
+      }
 
       // config dw connection when socket is open
       this.socket.on('open', () => {
@@ -224,6 +231,7 @@ export class DWClient extends EventEmitter {
             this.socket?.ping('', true);
           }, this.heartbeat_interval);
         }
+        resolve();
       });
 
       // wait for ping-pong with server
@@ -258,15 +266,23 @@ export class DWClient extends EventEmitter {
         // Without this, TLS handshake failures or other errors may not trigger 'close',
         // causing the client to stay disconnected forever when autoReconnect is enabled
         this.socket?.terminate();
+        reject(err);
       });
-
-      resolve();
     });
   }
 
   async connect() {
-    await this.getEndpoint();
-    await this._connect();
+    try {
+      await this.getEndpoint();
+      await this._connect();
+    } catch (err) {
+      if (this.config.autoReconnect && !this.userDisconnect) {
+        this.printDebug(
+          'Connect failed, retrying in ' + this.reconnectInterval / 1000 + ' seconds...'
+        );
+        setTimeout(() => this.connect(), this.reconnectInterval);
+      }
+    }
   }
 
   disconnect() {


### PR DESCRIPTION
## Summary / 摘要

This PR fixes all scenarios where `autoReconnect` would fail to reconnect the client.

本 PR 修复了所有导致 `autoReconnect` 无法自动重连的场景。

## Problem / 问题

When TLS handshake fails or other socket errors occur, the 'error' event is triggered but 'close' event may not fire. This causes the client to stay **disconnected forever**, even when `autoReconnect` is enabled.

当 TLS 握手失败或其他 socket 错误发生时，会触发 'error' 事件，但 'close' 事件可能不会触发。这导致即使启用了 `autoReconnect`，客户端也会**永远保持断开状态**。

## Changes / 改动

### 1. Handle WebSocket constructor errors / 处理 WebSocket 构造函数错误 (NEW)
Added try-catch around `new WebSocket()` to catch synchronous errors (e.g., TLS handshake failures during initial connection).

在 `new WebSocket()` 周围添加 try-catch，捕获同步错误（例如初始连接时的 TLS 握手失败）。

### 2. Fix Promise resolution timing / 修复 Promise 解析时机 (NEW)
Moved `resolve()` to the 'open' event callback, so the Promise only resolves after successful connection.

将 `resolve()` 移到 'open' 事件回调中，使 Promise 只在连接成功后解析。

### 3. Properly reject on errors / 正确处理错误时的 reject (IMPROVED)
Added `reject(err)` in both:
- 'error' event handler (runtime errors)  
- catch block (constructor errors)

在以下两处添加 `reject(err)`：
- 'error' 事件处理器（运行时错误）
- catch 代码块（构造函数错误）

### 4. Enable initial connection retry / 启用初始连接重试 (NEW)
Wrapped `connect()` body in try-catch to enable auto-retry for **initial connection failures**, not just runtime disconnections.

将 `connect()` 主体包装在 try-catch 中，为**初始连接失败**启用自动重试，而不仅是运行时断开。

## Testing / 测试

- [x] Initial connection TLS failure → auto-retry works / 初始连接 TLS 失败 → 自动重试有效
- [x] Runtime socket errors → auto-retry works (original fix) / 运行时 socket 错误 → 自动重试有效（原修复）
- [x] Normal close → still works as expected / 正常关闭 → 仍按预期工作
- [x] Manual disconnect → `userDisconnect` flag prevents reconnection / 手动断开 → `userDisconnect` 标志阻止重连

Tested in production with [OpenClaw](https://github.com/openclaw/openclaw).

已在 [OpenClaw](https://github.com/openclaw/openclaw) 生产环境测试通过。

## Related / 相关

Fixes: connection failures that cause client to stay disconnected forever when `autoReconnect: true`

修复：当 `autoReconnect: true` 时导致客户端永远断开的问题